### PR TITLE
Add coding strategy

### DIFF
--- a/Sources/ObjectEncoder/Decoder.swift
+++ b/Sources/ObjectEncoder/Decoder.swift
@@ -25,7 +25,7 @@ public struct ObjectDecoder {
     public struct DecodingStrategy<T: Decodable> {
         fileprivate let identifiers: [ObjectIdentifier]
         fileprivate let closure: (Decoder) throws -> T
-        init(_ types: [Any.Type] = [T.self], closure: @escaping (Decoder) throws -> T) {
+        public init(_ types: [Any.Type] = [T.self], closure: @escaping (Decoder) throws -> T) {
             self.closure = closure
             self.identifiers = types.map(ObjectIdentifier.init)
         }

--- a/Sources/ObjectEncoder/Decoder.swift
+++ b/Sources/ObjectEncoder/Decoder.swift
@@ -343,8 +343,10 @@ extension ObjectDecoder.DecodingStrategy {
 }
 
 extension ObjectDecoder.DecodingStrategy where T == Date {
-    /// Defer to `Date` for decoding. This is the default strategy.
-    static let deferredToDate = ObjectDecoder.DecodingStrategy<Date>([Date.self, NSDate.self]) { try Date(from: $0) }
+    /// Defer to `Date` for decoding.
+    public static let deferredToDate = ObjectDecoder.DecodingStrategy<Date>([Date.self, NSDate.self]) {
+        try Date(from: $0)
+    }
 
     /// Decode the `Date` as a UNIX timestamp from a `Double`.
     public static let secondsSince1970 = ObjectDecoder.DecodingStrategy<Date>([Date.self, NSDate.self]) {

--- a/Sources/ObjectEncoder/Encoder.swift
+++ b/Sources/ObjectEncoder/Encoder.swift
@@ -30,7 +30,7 @@ public struct ObjectEncoder {
     public struct EncodingStrategy<T: Encodable> {
         fileprivate let identifiers: [ObjectIdentifier]
         fileprivate let closure: (T, Encoder) throws -> Void
-        init(_ types: [Any.Type] = [T.self], closure: @escaping (T, Encoder) throws -> Void) {
+        public init(_ types: [Any.Type] = [T.self], closure: @escaping (T, Encoder) throws -> Void) {
             self.closure = closure
             self.identifiers = types.map(ObjectIdentifier.init)
         }

--- a/Sources/ObjectEncoder/Encoder.swift
+++ b/Sources/ObjectEncoder/Encoder.swift
@@ -378,7 +378,9 @@ var iso8601Formatter: ISO8601DateFormatter = {
 
 extension ObjectEncoder.EncodingStrategy where T == Date {
     /// Defer to `Date` for choosing an encoding. This is the default strategy.
-    static let deferredToDate = ObjectEncoder.EncodingStrategy<Date>([Date.self, NSDate.self]) { try $0.encode(to: $1) }
+    public static let deferredToDate = ObjectEncoder.EncodingStrategy<Date>([Date.self, NSDate.self]) {
+        try $0.encode(to: $1)
+    }
 
     /// Encode the `Date` as a UNIX timestamp (as a `Double`).
     public static let secondsSince1970 = ObjectEncoder.EncodingStrategy<Date>([Date.self, NSDate.self]) {

--- a/Sources/ObjectEncoder/Encoder.swift
+++ b/Sources/ObjectEncoder/Encoder.swift
@@ -356,6 +356,9 @@ struct _ObjectCodingKey: CodingKey { // swiftlint:disable:this type_name
 // MARK: - ObjectEncoder.EncodingStrategy
 
 extension ObjectEncoder {
+    /// The strategy to use for encoding `Data` values.
+    public typealias DataEncodingStrategy = EncodingStrategy<Data>
+    /// The strategy to use for encoding `Date` values.
     public typealias DateEncodingStrategy = EncodingStrategy<Date>
 }
 
@@ -366,6 +369,18 @@ extension ObjectEncoder.EncodingStrategy {
     /// the encoder will encode an empty automatic container in its place.
     public static func custom(_ closure: @escaping (T, Encoder) throws -> Void) -> ObjectEncoder.EncodingStrategy<T> {
         return .init(closure: closure)
+    }
+}
+
+extension ObjectEncoder.EncodingStrategy where T == Data {
+    /// Defer to `Data` for choosing an encoding.
+    public static let deferredToData = ObjectEncoder.EncodingStrategy<Data>([Data.self, NSData.self]) {
+        try $0.encode(to: $1)
+    }
+
+    /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.
+    public static let base64 = ObjectEncoder.EncodingStrategy<Data>([Data.self, NSData.self]) {
+        try $0.base64EncodedString().encode(to: $1)
     }
 }
 

--- a/Tests/ObjectEncoderTests/ObjectEncoderTests.swift
+++ b/Tests/ObjectEncoderTests/ObjectEncoderTests.swift
@@ -132,13 +132,13 @@ class ObjectEncoderTests: XCTestCase {
                                    line: UInt = #line) where T: Codable, T: Equatable {
         do {
             var encoder = ObjectEncoder()
-            encoder.dateEncodingStrategy = dateEncodingStrategy
+            encoder.encodingStrategies[Date.self] = dateEncodingStrategy
             let producedObject = try encoder.encode(object)
             if let produced = producedObject as? NSObject, let expected = expectedObject as? NSObject {
                 XCTAssertEqual(produced, expected, file: file, line: line)
             }
             var decoder = ObjectDecoder()
-            decoder.dateDecodingStrategy = dateDecodingStrategy
+            decoder.decodingStrategies[Date.self] = dateDecodingStrategy
             let decoded = try decoder.decode(T.self, from: producedObject)
             XCTAssertEqual(decoded, object, "\(T.self) did not round-trip to an equal value.",
                 file: file, line: line)

--- a/Tests/ObjectEncoderTests/ObjectEncoderTests.swift
+++ b/Tests/ObjectEncoderTests/ObjectEncoderTests.swift
@@ -5,8 +5,8 @@ import XCTest
 
 class ObjectEncoderTests: XCTestCase {
     func testValuesInSingleValueContainer() throws {
-        _testRoundTrip(of: true)
-        _testRoundTrip(of: false)
+        _testRoundTrip(of: true, expectedObject: true)
+        _testRoundTrip(of: false, expectedObject: false)
 
         _testFixedWidthInteger(type: Int.self)
         _testFixedWidthInteger(type: Int8.self)
@@ -22,8 +22,8 @@ class ObjectEncoderTests: XCTestCase {
         _testFloatingPoint(type: Float.self)
         _testFloatingPoint(type: Double.self)
 
-        _testRoundTrip(of: "")
-        _testRoundTrip(of: URL(string: "https://apple.com")!)
+        _testRoundTrip(of: "", expectedObject: "")
+        _testRoundTrip(of: URL(string: "https://apple.com")!, expectedObject: ["relative": "https://apple.com"])
     }
 
     func testValuesInKeyedContainer() throws {
@@ -111,16 +111,17 @@ class ObjectEncoderTests: XCTestCase {
     private func _testFixedWidthInteger<T>(type: T.Type,
                                            file: StaticString = #file,
                                            line: UInt = #line) where T: FixedWidthInteger & Codable {
-        _testRoundTrip(of: type.min, file: file, line: line)
-        _testRoundTrip(of: type.max, file: file, line: line)
+        _testRoundTrip(of: type.min, expectedObject: type.min, file: file, line: line)
+        _testRoundTrip(of: type.max, expectedObject: type.max, file: file, line: line)
     }
 
     private func _testFloatingPoint<T>(type: T.Type,
                                        file: StaticString = #file,
                                        line: UInt = #line) where T: FloatingPoint & Codable {
-        _testRoundTrip(of: type.leastNormalMagnitude, file: file, line: line)
-        _testRoundTrip(of: type.greatestFiniteMagnitude, file: file, line: line)
-        _testRoundTrip(of: type.infinity, file: file, line: line)
+        _testRoundTrip(of: type.leastNormalMagnitude, expectedObject: type.leastNormalMagnitude, file: file, line: line)
+        _testRoundTrip(of: type.greatestFiniteMagnitude,
+                       expectedObject: type.greatestFiniteMagnitude, file: file, line: line)
+        _testRoundTrip(of: type.infinity, expectedObject: type.infinity, file: file, line: line)
     }
 
     private func _testRoundTrip<T>(of object: T,

--- a/Tests/ObjectEncoderTests/ObjectEncoderTests.swift
+++ b/Tests/ObjectEncoderTests/ObjectEncoderTests.swift
@@ -55,18 +55,25 @@ class ObjectEncoderTests: XCTestCase {
     // MARK: - Date Strategy Tests
     func testEncodingDate() {
         _testRoundTrip(of: Date())
+    }
 
+    func testEncodingDateSecondsSince1970() {
         // Cannot encode an arbitrary number of seconds since we've lost precision since 1970.
         _testRoundTrip(of: Date(timeIntervalSince1970: 1000),
                        expectedObject: 1000.0,
                        dateEncodingStrategy: .secondsSince1970,
                        dateDecodingStrategy: .secondsSince1970)
+    }
+
+    func testEncodingDateMillisecondsSince1970() {
         // Cannot encode an arbitrary number of seconds since we've lost precision since 1970.
         _testRoundTrip(of: Date(timeIntervalSince1970: 1000),
                        expectedObject: 1000000.0,
                        dateEncodingStrategy: .millisecondsSince1970,
                        dateDecodingStrategy: .millisecondsSince1970)
+    }
 
+    func testEncodingDateISO8601() {
         if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
             // Cannot encode an arbitrary number of seconds since we've lost precision since 1970.
             _testRoundTrip(of: Date(timeIntervalSince1970: 1000),
@@ -74,7 +81,9 @@ class ObjectEncoderTests: XCTestCase {
                            dateEncodingStrategy: .iso8601,
                            dateDecodingStrategy: .iso8601)
         }
+    }
 
+    func testEncodingDateFormatted() {
         let formatter = DateFormatter()
         formatter.dateStyle = .full
         formatter.timeStyle = .full
@@ -85,7 +94,9 @@ class ObjectEncoderTests: XCTestCase {
                        expectedObject: "Thursday, January 1, 1970 at 12:16:40 AM Greenwich Mean Time",
                        dateEncodingStrategy: .formatted(formatter),
                        dateDecodingStrategy: .formatted(formatter))
+    }
 
+    func testEncodingDateCustom() {
         let timestamp = Date()
         // We'll encode a number instead of a date.
         let encodeNumber = { (_ data: Date, _ encoder: Encoder) throws -> Void in
@@ -97,7 +108,10 @@ class ObjectEncoderTests: XCTestCase {
                        expectedObject: 42,
                        dateEncodingStrategy: .custom(encodeNumber),
                        dateDecodingStrategy: .custom(decodeNumber))
+    }
 
+    func testEncodingDateCustomEmpty() {
+        let timestamp = Date()
         // Encoding nothing should encode an empty keyed container ({}).
         let encodeEmpty = { (_: Date, _: Encoder) throws -> Void in }
         let decodeEmpty = { (_: Decoder) throws -> Date in return timestamp }
@@ -126,8 +140,8 @@ class ObjectEncoderTests: XCTestCase {
 
     private func _testRoundTrip<T>(of object: T,
                                    expectedObject: Any? = nil,
-                                   dateEncodingStrategy: ObjectEncoder.DateEncodingStrategy = .deferredToDate,
-                                   dateDecodingStrategy: ObjectDecoder.DateDecodingStrategy = .deferredToDate,
+                                   dateEncodingStrategy: ObjectEncoder.DateEncodingStrategy? = nil,
+                                   dateDecodingStrategy: ObjectDecoder.DateDecodingStrategy? = nil,
                                    file: StaticString = #file,
                                    line: UInt = #line) where T: Codable, T: Equatable {
         do {
@@ -158,7 +172,13 @@ class ObjectEncoderTests: XCTestCase {
         ("testValuesInUnkeyedContainer", testValuesInUnkeyedContainer),
         ("testNestedContainerCodingPaths", testNestedContainerCodingPaths),
         ("testSuperEncoderCodingPaths", testSuperEncoderCodingPaths),
-        ("testEncodingDate", testEncodingDate)
+        ("testEncodingDate", testEncodingDate),
+        ("testEncodingDateSecondsSince1970", testEncodingDateSecondsSince1970),
+        ("testEncodingDateMillisecondsSince1970", testEncodingDateMillisecondsSince1970),
+        ("testEncodingDateISO8601", testEncodingDateISO8601),
+        ("testEncodingDateFormatted", testEncodingDateFormatted),
+        ("testEncodingDateCustom", testEncodingDateCustom),
+        ("testEncodingDateCustomEmpty", testEncodingDateCustomEmpty),
     ]
 }
 


### PR DESCRIPTION
- Add `ObjectEncoder.EncodingStrategy<T: Encodable>` and `ObjectDecoder.DecodingStrategy<T: Decodable>` that creating strategy
- Add `ObjectEncoder.encodingStrategies` and `ObjectDecoder.decodingStrategies` that holding strategies
- Add `ObjectEncoder.DateEncodingStrategies` and `ObjectDecoder.DateDecodingStrategies` as predefined strategies  with members:
  `.deferredToDate`, `.secondsSince1970`, `.millisecondsSince1970`, `.iso8601`, `.formatted(DateFormatter)`, `.custom((Decoder) throws -> T)`

Usage:
```swift
var encoder = ObjectEncoder()
encoder.encodingStrategies[Date.self] = .iso8601
let encoded = try encoder.encode(Date(timeIntervalSince1970: 1000))
encoded == "1970-01-01T00:16:40Z" // true

var decoder = ObjectDecoder()
decoder.decodingStrategies[Date.self] = .iso8601
let decoded = try decoder.decode(Date.self, from: encoded)
decoded == Date(timeIntervalSince1970: 1000) // true
```
